### PR TITLE
docs: add Chinese and English docs about installation pouch with virtual box.

### DIFF
--- a/blog-cn/PouchContainer_基于_Virtual_Box_快速安装_Pouch.md
+++ b/blog-cn/PouchContainer_基于_Virtual_Box_快速安装_Pouch.md
@@ -1,0 +1,92 @@
+# 使用 Virutal Box 安装并运行 PouchContainer
+
+本教程将指引你通过 Virtual Box 安装阿里的开源容器 Pouch，并通过 Pouch 运行起 Ubuntu。
+
+## 1. 打开 Virtual Box，并安装 Ubuntu 16.04 的系统
+
+打开 Virtual Box，安装 Ubuntu 16.04 的镜像，启动 Ubuntu 镜像以进行后续安装步骤。
+
+## 2. 安装 PouchContainer
+
+### 0. 先决条件
+
+PouchContainer 使用 LXCFS 来提供强大的个理性，因此你需要首先安装 LXCFS。同时，LXCFS 默认开启:
+
+``` bash
+sudo apt-get install lxcfs
+```
+
+安装相应的包，来允许 apt 命令使用 HTTPS 协议:
+
+``` bash
+sudo apt-get install curl apt-transport-https ca-certificates software-properties-common
+```
+
+### 1. 添加 PouchContainer 的官方 GPG 密钥
+
+``` bash
+curl -fsSL http://mirrors.aliyun.com/opsx/pouch/linux/debian/opsx@service.alibaba.com.gpg.key | sudo apt-key add -
+```
+
+现在，你可以通过搜索指纹的最后 8 位 `F443 EDD0 4A58 7E8B F645  9C40 CF68 F84A BE2F 475F` 来确认密钥是否正确添加。
+
+``` bash
+$ apt-key fingerprint BE2F475F
+pub   4096R/BE2F475F 2018-02-28
+      Key fingerprint = F443 EDD0 4A58 7E8B F645  9C40 CF68 F84A BE2F 475F
+uid                  opsx-admin <opsx@service.alibaba.com>
+```
+
+### 2. 设置 PouchContainer 的仓库
+
+在新主机上首次安装 PouchContainer 之前，需要先设置PouchContainer存储库。默认启用`stabel`存储库，`stable`存储库是必须要安装的。如果要添加`test`存储库，请在下面的命令行中的`stable`之后添加单词`test`。设置完仓库后，我们可以从存储库安装和更新PouchContainer。
+
+``` bash
+sudo add-apt-repository "deb http://mirrors.aliyun.com/opsx/pouch/linux/debian/ pouch stable"
+```
+
+### 3. 安装 PouchContainer
+
+安装最新版本的 PouchContainer
+
+``` bash
+# update the apt package index
+sudo apt-get update
+sudo apt-get install pouch
+```
+
+**4. 开启 PouchContainer **
+
+``` bash
+sudo service pouch start
+```
+
+### 5. 测试 PouchContainer 安装
+
+``` bash
+sudo pouch pull hello-world
+sudo pouch run hello-world
+```
+
+如果提示无法连接 registry.hub.docker.com，可以使用国内的镜像网站
+
+``` bash
+sudo pouch pull registry.docker-cn.com/library/hello-world
+sudo pouch run hello-world
+```
+
+## 3. 通过 PouchContainer 来执行 Ubuntu
+
+### 1. 拉取 Ubuntu 的镜像
+
+``` bash
+sudo pouch pull ubuntu
+```
+
+### 2. 执行 Ubuntu 镜像
+
+以交互模式启动 Ubuntu，并启动 tty:
+
+``` bash
+sudo pouch run -it ubuntu
+```

--- a/blog-en/Install_Pouch_With_Virtual_Box.md
+++ b/blog-en/Install_Pouch_With_Virtual_Box.md
@@ -1,0 +1,93 @@
+# Install and run PouchContainer with Virtual Box
+
+This tutorial will guide you install the open source container Pouch from Alibaba with Virtual Box. And run a Ubuntu image with PouchContainer.
+
+### 1. Open Virtual Box, and then install the Ubuntu 16.04
+
+Install Ubuntu 16.04 with Virtual Box. Lauch the image of Ubuntu.
+
+### 2. Install PouchContainer
+
+**Prerequisites**
+
+PouchContainer supports LXCFS to provide strong isolation, so you should install LXCFS firstly. By default, LXCFS is enabled.
+
+``` bash
+sudo apt-get install lxcfs
+```
+
+Install packages to allow 'apt' to use a repository over HTTPS:
+
+``` bash
+sudo apt-get install curl apt-transport-https ca-certificates software-properties-common
+```
+
+**1. Add PouchContainer's official GPG key**
+
+``` bash
+curl -fsSL http://mirrors.aliyun.com/opsx/pouch/linux/debian/opsx@service.alibaba.com.gpg.key | sudo apt-key add -
+```
+
+Verify that you now have the key with the fingerprint `F443 EDD0 4A58 7E8B F645  9C40 CF68 F84A BE2F 475F`, by searching for the last 8 characters of the fingerprint.
+
+``` bash
+$ apt-key fingerprint BE2F475F
+pub   4096R/BE2F475F 2018-02-28
+      Key fingerprint = F443 EDD0 4A58 7E8B F645  9C40 CF68 F84A BE2F 475F
+uid                  opsx-admin <opsx@service.alibaba.com>
+```
+
+**2. Set up the PouchContainer repository**
+
+Before you install PouchContainer for the first time on a new host machine, you need to set up the PouchContainer repository. We enabled `stabel` repository by default, you always need the `stable` repository. To add the `test` repository, add the word `test` after the word `stable` in the command line below. Afterward, you can install and update PouchContainer from the repository.
+
+``` bash
+sudo add-apt-repository "deb http://mirrors.aliyun.com/opsx/pouch/linux/debian/ pouch stable"
+```
+
+**3. Install PouchContainer**
+
+Install the latest version of PouchContainer.
+
+``` bash
+# update the apt package index
+sudo apt-get update
+sudo apt-get install pouch
+```
+
+After installing PouchContainer, the `pouch` group is created, but no users are added to the group.
+
+**4. Start PouchContainer**
+
+``` bash
+sudo service pouch start
+```
+
+**5. Verify the installation**
+
+``` bash
+sudo pouch pull hello-world
+sudo pouch run hello-world
+```
+
+If you cann't connect to registry.hub.docker.com, you can use the mirrors.
+
+``` bash
+sudo pouch pull registry.docker-cn.com/library/hello-world
+sudo pouch run hello-world
+```
+
+### 3. Run Ubuntu with PouchContainer
+
+**1. Pull the image of Ubuntu**
+
+``` bash
+sudo pouch pull ubuntu
+```
+
+**2. Run the image of Ubuntu**
+Run ubuntu in interactive mode, and allocate a pseudo-TTY:
+
+``` bash
+sudo pouch run -it ubuntu
+```


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
This PR adds docs Chinese and English about installation pouch with virtual box.

### Ⅱ. Does this pull request fix one issue?
fixes: #22 
fixes: #4 

### Ⅲ. Describe how you did it
Just install it with virtual box, and run it.

### Ⅳ. Describe how to verify it
Pull a ubuntu images from docker repos and run it.

### Ⅴ. Special notes for reviews
**SOME ISSUES:** If I use pouch run -it ubuntu directly (Without pull it), it will give me a error message.

``` bash 
Error: failed to run container: {"message":"image: registry.hub.docker.com/library/ubuntu: not found"}
```

But if I pull it firstly, it will be OK. I'm not sure it's a bug or not. I have try to use a mirrors of docker repos, but it doesn't work. 
I set the Virtual Box in NAT mode, the host machine is in Ali's internal networks.
